### PR TITLE
Add simple FastAPI app with GET and POST endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,36 @@
-# init
+# FastAPI 示例项目
+
+这是一个最简单的 FastAPI 应用程序，包含一个 GET 接口和一个 POST 接口。
+
+## 运行方法
+
+1. 安装依赖：
+
+   ```bash
+   pip install -r requirements.txt
+   ```
+
+2. 使用 Uvicorn 启动服务：
+
+   ```bash
+   uvicorn main:app --reload
+   ```
+
+3. 接口说明：
+   - `GET /`：返回欢迎信息。
+
+     **请求示例：**
+
+     ```bash
+     curl http://127.0.0.1:8000/
+     ```
+
+   - `POST /items`：接收一个包含 `name` 和可选 `description` 字段的 JSON 对象，并返回该对象。
+
+     **请求示例：**
+
+     ```bash
+     curl -X POST http://127.0.0.1:8000/items \
+       -H "Content-Type: application/json" \
+       -d '{"name": "Sample Item", "description": "An example item."}'
+     ```

--- a/main.py
+++ b/main.py
@@ -1,0 +1,26 @@
+"""Simple FastAPI application with GET and POST endpoints."""
+
+from fastapi import FastAPI
+from pydantic import BaseModel
+from typing import Optional
+
+app = FastAPI()
+
+
+@app.get("/")
+async def read_root() -> dict:
+    """Return a simple greeting message."""
+    return {"message": "Hello from FastAPI!"}
+
+
+class Item(BaseModel):
+    """Request body model for the POST endpoint."""
+
+    name: str
+    description: Optional[str] = None
+
+
+@app.post("/items")
+async def create_item(item: Item) -> dict:
+    """Echo the received item data back to the client."""
+    return {"message": "Item received", "item": item}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+fastapi
+uvicorn


### PR DESCRIPTION
## Summary
- add a minimal FastAPI application with GET and POST endpoints
- document how to run the service, describe the available routes, and include sample requests
- provide a requirements file for dependencies

## Testing
- python -m py_compile main.py

------
https://chatgpt.com/codex/tasks/task_e_68d3cd4ec71483208b12d0013da180a0